### PR TITLE
fix: allow leaving the ingress backend empty in GPP-zoeken and GPP-publicatiebank

### DIFF
--- a/charts/GPP-publicatiebank/CHANGELOG.md
+++ b/charts/GPP-publicatiebank/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1 (2025-03-25)
+
+- Allow leaving the ingress backend empty.
+
 ## 2.0.0 (2025-03-21)
 
 - Added Flower

--- a/charts/GPP-publicatiebank/Chart.yaml
+++ b/charts/GPP-publicatiebank/Chart.yaml
@@ -3,7 +3,7 @@ name: gpp-publicatiebank
 description: Een registratie die voorziet in de "Openbare Documenten opslag"-functionaliteiten
 
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: 0.1.0
 
 dependencies:

--- a/charts/GPP-publicatiebank/templates/ingress.yaml
+++ b/charts/GPP-publicatiebank/templates/ingress.yaml
@@ -49,9 +49,9 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ .backend.service.name | default ($fullName) }}
+                name: {{ ((.backend).service).name | default ($fullName) }}
                 port:
-                  number: {{ .backend.service.port.number | default ($svcPort) }}
+                  number: {{ (((.backend).service).port).number | default ($svcPort) }}
               {{- else }}
               serviceName: {{ .serviceName | default ($fullName) }}
               servicePort: {{ .servicePort | default ($svcPort) }}

--- a/charts/GPP-zoeken/CHANGELOG.md
+++ b/charts/GPP-zoeken/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1 (2025-03-25)
+
+- Allow leaving the ingress backend empty.
+
 ## 0.2.0 (2025-03-21)
 
 - Add Flower. 

--- a/charts/GPP-zoeken/Chart.yaml
+++ b/charts/GPP-zoeken/Chart.yaml
@@ -3,7 +3,7 @@ name: gpp-zoeken
 description: Een zoek-component die voorziet in een "Openbare documenten"-index.
 
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.1.0
 
 dependencies:

--- a/charts/GPP-zoeken/templates/ingress.yaml
+++ b/charts/GPP-zoeken/templates/ingress.yaml
@@ -49,9 +49,9 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ .backend.service.name | default ($fullName) }}
+                name: {{ ((.backend).service).name | default ($fullName) }}
                 port:
-                  number: {{ .backend.service.port.number | default ($svcPort) }}
+                  number: {{ (((.backend).service).port).number | default ($svcPort) }}
               {{- else }}
               serviceName: {{ .serviceName | default ($fullName) }}
               servicePort: {{ .servicePort | default ($svcPort) }}


### PR DESCRIPTION
Allows yo to do
```yaml
ingress:
  hosts:
    - host: example.com
      paths:
        - path: /
          pathType: ImplementationSpecific
```
in stead of
```yaml
ingress:
  hosts:
    - host: example.com
      paths:
        - pathType: ImplementationSpecific
          path: "/"
          backend:
            service:
              name:
              port:
                number:
```