### PR TITLE
bump publicatiebank version

### DIFF
--- a/charts/GPP-publicatiebank/CHANGELOG.md
+++ b/charts/GPP-publicatiebank/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2 (2025-03-26)
+
+- Use the correct appname in the celery command/
+
 ## 2.0.1 (2025-03-25)
 
 - Allow leaving the ingress backend empty.

--- a/charts/GPP-publicatiebank/Chart.yaml
+++ b/charts/GPP-publicatiebank/Chart.yaml
@@ -3,7 +3,7 @@ name: gpp-publicatiebank
 description: Een registratie die voorziet in de "Openbare Documenten opslag"-functionaliteiten
 
 type: application
-version: 2.0.1
+version: 2.0.2
 appVersion: 0.1.0
 
 dependencies:


### PR DESCRIPTION
A minor change happened in the publicatiebank within the umbrella chart pr, so we need to bump publicatiebank to fix the build.