### PR TITLE
Support the v2 version of the bestandsdelen route in the publicatiebank nginx proxy

### DIFF
--- a/charts/GPP-publicatiebank/CHANGELOG.md
+++ b/charts/GPP-publicatiebank/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.7 (2026-01-21)
+
+- Allow any api version in the regex for the bestandsdelen route in the nginx proxy that sets the `client_max_body_size` to `Values.documentMaxBodySize` 
+
 ## 2.0.6 (2025-09-03)
 
 - Set appVersion to 2.0.0

--- a/charts/GPP-publicatiebank/Chart.yaml
+++ b/charts/GPP-publicatiebank/Chart.yaml
@@ -3,7 +3,7 @@ name: gpp-publicatiebank
 description: Een registratie die voorziet in de "Openbare Documenten opslag"-functionaliteiten
 
 type: application
-version: 2.0.6
+version: 2.0.7
 appVersion: 2.0.0
 
 dependencies:

--- a/charts/GPP-publicatiebank/README.md
+++ b/charts/GPP-publicatiebank/README.md
@@ -1,6 +1,6 @@
 # gpp-publicatiebank
 
-![Version: 2.0.6](https://img.shields.io/badge/Version-2.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 2.0.7](https://img.shields.io/badge/Version-2.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 Een registratie die voorziet in de "Openbare Documenten opslag"-functionaliteiten
 

--- a/charts/GPP-publicatiebank/templates/configmap-nginx.yaml
+++ b/charts/GPP-publicatiebank/templates/configmap-nginx.yaml
@@ -67,7 +67,7 @@ data:
         }
         {{- end }}
 
-        location ~ ^/api/v1/documenten/[a-fA-F0-9-]+/bestandsdelen/[a-fA-F0-9-]+$ {
+        location ~ ^/api/v[0-9]+/documenten/[a-fA-F0-9-]+/bestandsdelen/[a-fA-F0-9-]+$ {
           client_max_body_size {{ .Values.settings.documentMaxBodySize | default "4G" }};
           include conf.d/proxy;
         }


### PR DESCRIPTION
The gpp-app uses v2 of the publicatiebank api, but the nginx proxy route that sets the max body size, is only matching v1.