### PR TITLE
feat: accept nginx.config timeout and transferlimit tweaks like openzaak

### DIFF
--- a/charts/GPP-publicatiebank/CHANGELOG.md
+++ b/charts/GPP-publicatiebank/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0 (2026-06-03)
+
+- Expose nginx settings `nginx.config.clientMaxBodySize`, `nginx.config.proxyConnectTimeoutSeconds` and `nginx.config.proxyReadTimeoutSeconds` for configuration via Helm values.
+
 ## 2.0.8 (2026-04-22)
 
 - Set appVersion to 2.1.0

--- a/charts/GPP-publicatiebank/Chart.yaml
+++ b/charts/GPP-publicatiebank/Chart.yaml
@@ -3,7 +3,7 @@ name: gpp-publicatiebank
 description: Een registratie die voorziet in de "Openbare Documenten opslag"-functionaliteiten
 
 type: application
-version: 2.0.8
+version: 2.1.0
 appVersion: 2.1.0
 
 dependencies:

--- a/charts/GPP-publicatiebank/README.md
+++ b/charts/GPP-publicatiebank/README.md
@@ -66,6 +66,9 @@ Een registratie die voorziet in de "Openbare Documenten opslag"-functionaliteite
 | livenessProbe.timeoutSeconds | int | `5` |  |
 | nameOverride | string | `""` |  |
 | nginx.autoscaling.enabled | bool | `false` |  |
+| nginx.config.clientMaxBodySize | string | `"4G"` | Default client_max_body_size for all endpoints (unless overridden). Examples: "10M", "100M", "1G", "4G", "10G". |
+| nginx.config.proxyConnectTimeoutSeconds | int | `300` | Proxy connection timeout in seconds. How long nginx waits to establish a connection with the backend. |
+| nginx.config.proxyReadTimeoutSeconds | int | `300` | Proxy read timeout in seconds. How long nginx waits for a backend response. |
 | nginx.existingConfigmap | string | `nil` |  |
 | nginx.image.pullPolicy | string | `"IfNotPresent"` |  |
 | nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` |  |

--- a/charts/GPP-publicatiebank/README.md
+++ b/charts/GPP-publicatiebank/README.md
@@ -1,6 +1,6 @@
 # gpp-publicatiebank
 
-![Version: 2.0.8](https://img.shields.io/badge/Version-2.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Een registratie die voorziet in de "Openbare Documenten opslag"-functionaliteiten
 

--- a/charts/GPP-publicatiebank/templates/configmap-nginx.yaml
+++ b/charts/GPP-publicatiebank/templates/configmap-nginx.yaml
@@ -9,8 +9,8 @@ data:
   proxy: |
     proxy_pass_header Server;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_connect_timeout 300s;
-    proxy_read_timeout 300s;
+    proxy_connect_timeout {{ .Values.nginx.config.proxyConnectTimeoutSeconds }}s;
+    proxy_read_timeout {{ .Values.nginx.config.proxyReadTimeoutSeconds }}s;
     proxy_redirect off;
     proxy_pass_request_headers on;
     proxy_http_version 1.1;
@@ -26,6 +26,8 @@ data:
         listen 8080 default_server;
         server_name {{ .Values.settings.allowedHosts  | replace "," " "}} localhost;
         server_tokens off;
+
+        client_max_body_size {{ .Values.nginx.config.clientMaxBodySize }};
 
         gzip  on;
         gzip_http_version 1.0;

--- a/charts/GPP-publicatiebank/values.yaml
+++ b/charts/GPP-publicatiebank/values.yaml
@@ -307,6 +307,13 @@ nginx:
     pullPolicy: IfNotPresent
     tag: stable
   existingConfigmap: null
+  config:
+    # -- Proxy connection timeout in seconds. How long nginx waits to establish a connection with the backend.
+    proxyConnectTimeoutSeconds: 300
+    # -- Proxy read timeout in seconds. How long nginx waits for a backend response.
+    proxyReadTimeoutSeconds: 300
+    # -- Default client_max_body_size for all endpoints (unless overridden). Examples: "10M", "100M", "1G", "4G", "10G".
+    clientMaxBodySize: "4G"
   service:
     type: ClusterIP
     port: 80

--- a/charts/GPP-stack/README.md
+++ b/charts/GPP-stack/README.md
@@ -449,6 +449,9 @@ An umbrella chart for the GPP stack
 | gpp-publicatiebank.livenessProbe.timeoutSeconds | int | `5` |  |
 | gpp-publicatiebank.nameOverride | string | `""` |  |
 | gpp-publicatiebank.nginx.autoscaling.enabled | bool | `false` |  |
+| gpp-publicatiebank.nginx.config.clientMaxBodySize | string | `"4G"` | Default client_max_body_size for all endpoints (unless overridden). Examples: "10M", "100M", "1G", "4G", "10G". |
+| gpp-publicatiebank.nginx.config.proxyConnectTimeoutSeconds | int | `300` | Proxy connection timeout in seconds. How long nginx waits to establish a connection with the backend. |
+| gpp-publicatiebank.nginx.config.proxyReadTimeoutSeconds | int | `300` | Proxy read timeout in seconds. How long nginx waits for a backend response. |
 | gpp-publicatiebank.nginx.existingConfigmap | string | `nil` |  |
 | gpp-publicatiebank.nginx.image.pullPolicy | string | `"IfNotPresent"` |  |
 | gpp-publicatiebank.nginx.image.repository | string | `"nginxinc/nginx-unprivileged"` |  |


### PR DESCRIPTION
Similarly to the openzaak chart (https://github.com/maykinmedia/charts/blob/main/charts/openzaak/), expose charts/GPP-publicatiebank/ nginx config settings for overrides via Helm values:
- nginx.config.clientMaxBodySize
- nginx.config.proxyConnectTimeoutSeconds
- nginx.config.proxyReadTimeoutSeconds
Default values identical to those from openzaak.