### PR TITLE
feat: patch release GPP-stack with GPP-publicatiebank update (GPPWOO-81)

### DIFF
--- a/charts/GPP-stack/CHANGELOG.md
+++ b/charts/GPP-stack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1 (2026-06-04)
+- Bumped GPP-publicatiebank to 2.1.0.
+- Bumped GPP-stack appVersion to 1.0.1.
+
 ## 0.3.0 (2026-04-22)
 
 - Bumped GPP-app to 0.3.2.

--- a/charts/GPP-stack/Chart.lock
+++ b/charts/GPP-stack/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.3.2
 - name: gpp-publicatiebank
   repository: https://GPP-Woo.github.io/charts
-  version: 2.0.8
+  version: 2.1.0
 - name: gpp-burgerportaal
   repository: https://GPP-Woo.github.io/charts
   version: 2.0.0
 - name: gpp-zoeken
   repository: https://GPP-Woo.github.io/charts
   version: 0.2.6
-digest: sha256:0d636e150b76026d38ff8638f8f362965457bcd35a807f1b80c2d3843ad59b67
-generated: "2026-04-22T12:23:25.2051408+02:00"
+digest: sha256:2d54873f9bb11bbfffc5c0e9408151d52c8f079baeb35ba3b89b1ae0c4e3f4cb
+generated: "2026-06-04T10:30:01.319513701+02:00"

--- a/charts/GPP-stack/Chart.yaml
+++ b/charts/GPP-stack/Chart.yaml
@@ -5,9 +5,9 @@ description: An umbrella chart for the GPP stack
 type: application
 
 # Chart version
-version: 0.3.0
+version: 0.3.1
 
-appVersion: "0.1.0"
+appVersion: "1.0.1"
 
 dependencies:
   - name: openzaak
@@ -21,7 +21,7 @@ dependencies:
     condition: gpp-app.enabled
 
   - name: gpp-publicatiebank
-    version: 2.0.8
+    version: 2.1.0
     repository: https://GPP-Woo.github.io/charts
     condition: gpp-publicatiebank.enabled
 

--- a/charts/GPP-stack/README.md
+++ b/charts/GPP-stack/README.md
@@ -1,6 +1,6 @@
 # gpp-stack
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
 
 An umbrella chart for the GPP stack
 
@@ -10,7 +10,7 @@ An umbrella chart for the GPP stack
 |------------|------|---------|
 | https://GPP-Woo.github.io/charts | gpp-app | 0.3.2 |
 | https://GPP-Woo.github.io/charts | gpp-burgerportaal | 2.0.0 |
-| https://GPP-Woo.github.io/charts | gpp-publicatiebank | 2.0.8 |
+| https://GPP-Woo.github.io/charts | gpp-publicatiebank | 2.1.0 |
 | https://GPP-Woo.github.io/charts | gpp-zoeken | 0.2.6 |
 | https://maykinmedia.github.io/charts/ | openzaak | 1.13.1 |
 


### PR DESCRIPTION
GPP-stack 0.3.1 bumps:
- GPP-publicatiebank to 2.1.0
- appVersion to 1.0.1