### PR TITLE
fix(GPP-burgerportaal): honour 0 for sitemapCacheDurationHours and downloadTimeoutMinutes

### DIFF
--- a/charts/GPP-burgerportaal/Chart.yaml
+++ b/charts/GPP-burgerportaal/Chart.yaml
@@ -4,7 +4,7 @@ description: A helm chart for the ICATT GPP burgerportaal.
 
 type: application
 
-# Chart version 
-version: 2.0.0
+# Chart version
+version: 2.0.1
 appVersion: 5.0.0
 

--- a/charts/GPP-burgerportaal/README.md
+++ b/charts/GPP-burgerportaal/README.md
@@ -1,6 +1,6 @@
 # gpp-burgerportaal
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.0.0](https://img.shields.io/badge/AppVersion-5.0.0-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.0.0](https://img.shields.io/badge/AppVersion-5.0.0-informational?style=flat-square)
 
 A helm chart for the ICATT GPP burgerportaal.
 

--- a/charts/GPP-burgerportaal/templates/configmap.yaml
+++ b/charts/GPP-burgerportaal/templates/configmap.yaml
@@ -28,10 +28,14 @@ data:
   OIDC_NAME_CLAIM_TYPE: {{ .Values.settings.oidc.nameClaimType | toString | quote }}
   {{- end }}
   SEARCH_BASE_URL: {{ .Values.settings.search.baseUrl | toString | quote }}
-  {{- if .Values.settings.sitemapCacheDurationHours }}
+  {{- /* Render on "is it set?", not on truthiness: 0 is falsy in Go templates, so a
+         plain `if` silently drops the one value a testomgeving most wants to set —
+         0 hours to disable the sitemap output cache. The app then falls back to its
+         own 23h default and serves a stale (often empty) sitemap all day. */}}
+  {{- if not (kindIs "invalid" .Values.settings.sitemapCacheDurationHours) }}
   SITEMAP_CACHE_DURATION_HOURS: {{ .Values.settings.sitemapCacheDurationHours | toString | quote }}
   {{- end }}
-  {{- if .Values.settings.downloadTimeoutMinutes }}
+  {{- if not (kindIs "invalid" .Values.settings.downloadTimeoutMinutes) }}
   DOWNLOAD_TIMEOUT_MINUTES: {{ .Values.settings.downloadTimeoutMinutes | toString | quote }}
   {{- end }}
   RESOURCES__PORTAAL_TITEL	: {{ .Values.settings.resources.portaalTitel | toString | quote }}


### PR DESCRIPTION
## Wat is er aan de hand

`charts/GPP-burgerportaal/templates/configmap.yaml` rendert deze twee settings op *truthiness*:

```gotemplate
{{- if .Values.settings.sitemapCacheDurationHours }}
SITEMAP_CACHE_DURATION_HOURS: {{ ... }}
{{- end }}
```

In Go templates is **`0` falsy**. Dus juist de waarde die je op een testomgeving wilt zetten — `sitemapCacheDurationHours: 0` om de sitemap-outputcache uit te zetten — verdwijnt stilletjes uit de ConfigMap. De app valt dan terug op zijn eigen default van **23 uur**.

Hetzelfde geldt voor `downloadTimeoutMinutes`.

## Hoe dit zich uitte

In de e2e-pipeline (kind + deze charts) bouwde de burgerportaal de sitemap **één keer**, vroeg in de run terwijl de stack nog leeg was, en serveerde die lege XML de rest van de suite uit de cache:

```
45 x "Serving response from cache."
 1 x "Sending HTTP request"      <- één enkele ODRC-call in de hele run
```

Gevolg: elk scenario dat een document seedt en daarna in de sitemap opzoekt viel om tegen een sitemap met 0 entries, terwijl ODRC 20-40 documenten als `gepubliceerd` + `isGereedVoorPublicatie` rapporteerde. Dat leest als een propagatie- of timingbug in de tests, en dat is het niet.

## De fix

Renderen op "is de waarde gezet?" in plaats van op truthiness:

```gotemplate
{{- if not (kindIs "invalid" .Values.settings.sitemapCacheDurationHours) }}
```

Geverifieerd met `helm template`:

| waarde | voor | na |
|---|---|---|
| `sitemapCacheDurationHours: 0` | env var **afwezig** | `SITEMAP_CACHE_DURATION_HOURS: "0"` |
| default (`23`) | `"23"` | `"23"` |
| expliciet `null` | afwezig | afwezig |

`helm lint charts/GPP-burgerportaal` is schoon.

## Chart version

`gpp-burgerportaal` gaat naar **2.0.1** — de release-workflow publiceert een chart alleen als de versie wijzigt, dus zonder bump bereikt de fix niemand.

## Follow-up (bewust niet in deze PR)

`charts/GPP-stack/Chart.yaml` pint `gpp-burgerportaal: 2.0.0`, dus consumers van de umbrella krijgen deze fix nog niet. Ik heb die bump er **niet** in gelaten: chart-releaser resolvet de dependencies van `gpp-stack` uit de gepubliceerde index, en `2.0.1` bestaat daar pas nadat deze merge zelf gepubliceerd is — een bump in dezelfde PR kan de release-run dus laten falen. Beter een losse bump nadat 2.0.1 er staat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)